### PR TITLE
Add `parseOptionsString` to extract `type` and `action` from a `src` …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.0
+Add `parseOptionsString` to extract `type` and `action` from a `src` string
+Make `getRouteData` use `parseOptionsString`
+
 # 1.1.2
 Supporting Async / Await in postPolicy
 

--- a/index.js
+++ b/index.js
@@ -55,11 +55,14 @@ let postPolicy = (fn, before=_.noop) => async (req, res, next) => {
   next()
 }
 
-// Gets controller/method info for a route
-let getRouteData = ({ options: {action} }) => ({
-  type: _.dropRight(1, action.split('/')).join('-'),
-  action: _.last(action.split('/'))
+// Gets controller/method info from a string src
+let parseOptionsString = (src) => ({
+  type: _.dropRight(1, src.split('/')).join('-'),
+  action: _.last(src.split('/'))
 })
+
+// Gets controller/method info for a route
+let getRouteData = ({ options: {action}}, actionNameSrc) => parseOptionsString(action)
 
 module.exports = {
   send,
@@ -72,5 +75,6 @@ module.exports = {
   controller,
 
   postPolicy,
-  getRouteData
+  getRouteData,
+  parseOptionsString
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-async",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Utilities to enable async/promise methods for controllers and policies",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
…string

Add `parseOptionsString` to extract `type` and `action` from a `src` string
Make `getRouteData` use `parseOptionsString`