### PR TITLE
bind original res.send to res because the context of the arrow functi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.3.3
+Fix issue with res.send in postPolicy
+
 # 1.3.2
 Add duti to the repo
 

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ let postPolicy = (fn, before=_.noop) => async (req, res, next) => {
   let resFn = res.send
   res.send = async (...args) => {
     await fn(req, res, ...args)
-    return resFn(...args)
+    return resFn.call(res, ...args)
   }
   await before(req, res)
   next()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-async",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Utilities to enable async/promise methods for controllers and policies",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
…on makes "this" undefined in the scope of res.send