### PR TITLE
Update duti to latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.3.5
+Use latest duti version
+
 # 1.3.4
 Add `bool` to support multiple policies condition (A policy and/or B policy)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-async",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Utilities to enable async/promise methods for controllers and policies",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lodash": "^4.17.4"
   },
   "devDependencies": {
-    "duti": "^0.3.2"
+    "duti": "latest"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Makes duti use `latest` instead of pinning to a version.