### PR TITLE
Fixing res.send issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+﻿# 1.3.7
+Fixed res.send issue
+
 # 1.3.6
 Always run duti in Circle
 

--- a/bool.js
+++ b/bool.js
@@ -71,7 +71,7 @@ module.exports = _.extend(function (combinator, policies) {
         return result
       })
     }).then(function (results) {
-      if (passed) { next() } else { res.send(401, _.map(results, 'body')) }
+      if (passed) { next() } else { res.status(401).send(_.map(results, 'body')) }
     })
   }
 }, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-async",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Utilities to enable async/promise methods for controllers and policies",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
It was showing an error on console because `res.send(401...` is deprecated.